### PR TITLE
Make internal numerical id accessable

### DIFF
--- a/janus/views.py
+++ b/janus/views.py
@@ -237,6 +237,7 @@ class ProfileView(ProtectedResourceView):
 
         data = {
             'id': user.username,
+            'internal_id': user.id,
             'first_name': user.first_name,
             'last_name': user.last_name,
             'name': user.first_name + ' ' + user.last_name,


### PR DESCRIPTION
Mattermost requires a numerical id, therefore we use the internal database id which is numerical and unique

Example profile replace json:
```
{
"id": "login",
"internal_id": "id"
}
```