### PR TITLE
Restrict django_python3_ldap version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "django>=2.0,<4.0",
         "django-oauth-toolkit==1.3.2",
         "django-cors-middleware>=1.5.0",
-        "django_python3_ldap>=0.11.3",
+        "django_python3_ldap>=0.11.3,<0.15.0",
         "django-allauth>=0.42.0",
         "django-fakeinline>=0.1.1",
     ],


### PR DESCRIPTION
django_python3_ldap >= 0.15.0 is broken. 0.14.0 is the last working one.