### PR TITLE
OIDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ custom profile endpoint, returns user profile information as json:
 ````
 
 #### extend profile response
+##### Old
 overwrite settings like this:
 `ALLAUTH_JANUS_PROFILE_VIEW = 'app.views.ProfileViewCustom'`
 
@@ -198,6 +199,10 @@ class ProfileViewCustom(ProfileView):
         data['custom_values'] = user.custom_user_value
         return data
 ```
+
+##### New (OIDC)
+Extend `JanusOAuth2Validator`. You can then modify the response by [adding additional information to the `UserInfo` service directly](https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html#adding-information-to-the-userinfo-service) or by [adding claims to the ID token](https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html#adding-claims-to-the-id-token).
+Then set the modified Validator as `OAUTH2_VALIDATOR_CLASS` in the `OAUTH2_PROVIDER` in the settings. See also the section on `enable and configure OIDC` for the configuration of the settings.
 
 ## OIDC endpoints
 ### `o/userinfo/`

--- a/janus/__init__.py
+++ b/janus/__init__.py
@@ -1,1 +1,1 @@
-__version__ = VERSION = (1, 3, 1)
+__version__ = VERSION = (1, 3, 2)

--- a/janus/admin.py
+++ b/janus/admin.py
@@ -10,6 +10,7 @@ from janus.models import Profile, ApplicationGroup, ProfilePermission, GroupPerm
     ApplicationExtension
 from django.contrib.auth.admin import UserAdmin
 
+from janus.oauth2.util import get_group_list
 
 
 ###################################################
@@ -54,15 +55,12 @@ class ApplicationGroupFormSet(FakeFormSetNew):
     def get_applications(self):
         user = self.instance
 
-        from janus.views import ProfileView
-        pv = ProfileView()
-
         ret = {}
 
         applications = get_application_model().objects.all()
 
         for application in applications:
-            ret[application.name] = pv.get_group_list(user, application)
+            ret[application.name] = get_group_list(user, application)
 
         return ret
 

--- a/janus/app_settings.py
+++ b/janus/app_settings.py
@@ -3,3 +3,10 @@ from django.conf import settings
 ALLAUTH_JANUS_PROFILE_VIEW = getattr(settings, 'ALLAUTH_JANUS_PROFILE_VIEW', 'janus.views.ProfileView')
 
 ALLAUTH_JANUS_ADMIN_CLASS = getattr(settings, 'ALLAUTH_JANUS_ADMIN_CLASS', 'janus.admin.JanusUserAdmin')
+
+# Enable OIDC only if it is enabled in django-oauth-toolkit.
+OAUTH_SETTINGS = getattr(settings, 'OAUTH2_PROVIDER', {})
+JANUS_OIDC_ENABLED = OAUTH_SETTINGS.get('OIDC_ENABLED', False)
+
+# janus supports some non-standard claims. Set which scope is required to return the claims.
+JANUS_OIDC_SCOPE_EXTRA = getattr(settings, 'JANUS_OIDC_SCOPE_EXTRA', 'janus')

--- a/janus/oauth2/util.py
+++ b/janus/oauth2/util.py
@@ -1,0 +1,145 @@
+from janus.models import ProfileGroup, Profile, GroupPermission, ProfilePermission
+
+
+def get_profile_memberships(user):
+    all_profiles = Profile.objects.get(user=user).group.all()
+
+    # add the default groups by default
+    default_profile = ProfileGroup.objects.filter(default=True)
+    all_profiles = set(all_profiles | default_profile)
+
+    return list(all_profiles)
+
+
+def get_group_permissions(user, application):
+    """
+    Validates the group permissions for a user given a token
+    :param user:
+    :param token:
+    :return:
+    """
+    is_staff = False
+    is_superuser = False
+    can_authenticate = False
+
+    if not user.is_authenticated:
+        return can_authenticate, is_staff, is_superuser
+
+    all_groups = get_profile_memberships(user)
+
+    for g in all_groups:
+        gp = GroupPermission.objects.filter(profile_group=g, application=application)
+        if gp.count() == 0:
+            continue
+        elif gp.count() == 1:
+            gp = gp.first()
+            if gp.can_authenticate:
+                can_authenticate = True
+            if gp.is_staff:
+                is_staff = True
+            if gp.is_superuser:
+                is_superuser = True
+        else:
+            print('We have a problem')
+    return can_authenticate, is_staff, is_superuser
+
+
+def get_personal_permissions(user, application):
+    """
+    Validates the personal permissions for a user given a token
+    :param user:
+    :param token:
+    :return:
+    """
+    is_staff = None
+    is_superuser = None
+    can_authenticate = None
+    if not user.is_authenticated:
+        return can_authenticate, is_staff, is_superuser
+
+    pp = ProfilePermission.objects.filter(profile__user=user, application=application).first()
+    if pp:
+        is_staff = True if pp.is_staff else None
+        is_superuser = True if pp.is_superuser else None
+        can_authenticate = True if pp.can_authenticate else None
+    return can_authenticate, is_staff, is_superuser
+
+
+def get_profile_group_memberships(user, application):
+    """
+    collect group names form user profile group memberships
+    :param user:
+    :param token:
+    :return:
+    """
+
+    all_profiles = get_profile_memberships(user)
+
+    group_list = set()
+
+    for g in all_profiles:
+        # get profile-group-permission object
+        gp = GroupPermission.objects.filter(profile_group=g, application=application)
+        for elem in gp:
+            groups = elem.groups.all()
+
+            for g in groups:
+                # ensure only groups for this application can be returned
+                if g.application == application:
+                    group_list.add(g.name)
+
+    return group_list
+
+
+def get_profile_personal_memberships(user, application):
+    """
+    collect group names form user profile permission
+    :param user:
+    :param token:
+    :return:
+    """
+
+    profile_permissions = ProfilePermission.objects.filter(profile__user=user, application=application).first()
+
+    group_list = set()
+
+    if profile_permissions:
+        groups = profile_permissions.groups.all()
+
+        for g in groups:
+            # ensure only groups for this application can be returned
+            if g.application == application:
+                group_list.add(g.name)
+
+    return group_list
+
+
+def get_permissions(user, application):
+    """
+    return permissions according to application settings, personal overwrite and default values
+    :param user:
+    :param application:
+    :return:
+    """
+    can_authenticate, is_staff, is_superuser = get_group_permissions(user, application)
+
+    # if set the personal settings overwrite the user settings
+    pp_authenticate, pp_staff, pp_superuser = get_personal_permissions(user, application)
+    if pp_staff is not None:
+        is_staff = pp_staff
+
+    if pp_superuser is not None:
+        is_superuser = pp_superuser
+
+    if pp_authenticate is not None:
+        can_authenticate = pp_authenticate
+
+    return can_authenticate, is_staff, is_superuser
+
+
+def get_group_list(user, application):
+    groups = set()
+    groups = groups.union(get_profile_group_memberships(user, application))
+    groups = groups.union(get_profile_personal_memberships(user, application))
+
+    return list(groups)

--- a/janus/oauth2/validator.py
+++ b/janus/oauth2/validator.py
@@ -1,0 +1,45 @@
+from allauth.account.models import EmailAddress
+from oauth2_provider.oauth2_validators import OAuth2Validator
+
+from janus import app_settings
+from janus.oauth2.util import get_permissions, get_group_list
+
+
+class JanusOAuth2Validator(OAuth2Validator):
+    # As per 5.4 of the OIDC Core Specs the OIDC Scopes are used to determine which claims are returned.
+    # See https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
+    # Update with additional non-standard claims we support.
+    oidc_claim_scope = OAuth2Validator.oidc_claim_scope
+    oidc_claim_scope.update({"is_staff": app_settings.JANUS_OIDC_SCOPE_EXTRA,
+                             "is_superuser": app_settings.JANUS_OIDC_SCOPE_EXTRA,
+                             "can_authenticate": app_settings.JANUS_OIDC_SCOPE_EXTRA,
+                             "groups": app_settings.JANUS_OIDC_SCOPE_EXTRA
+                             })
+
+    def get_additional_claims(self, request):
+        # The default implementation only returns very little data.
+        # Return the data for the additional claims that we want support.
+
+        user = request.user
+
+        can_authenticate, is_staff, is_superuser = get_permissions(user, request.client)
+
+        # The `sub` claim is a unique id for a user. The `sub` claim is always returned.
+        return {
+            "name": ' '.join([user.first_name, user.last_name]),
+            "given_name": user.first_name,
+            "family_name": user.last_name,
+            "preferred_username": user.username,
+            "email": user.email,
+            "email_verified": EmailAddress.objects.filter(user=user, verified=True).exists(),
+            "is_staff": is_staff,
+            "is_superuser": is_superuser,
+            # TODO: Is `can_authenticate` required?
+            "can_authenticate": can_authenticate,
+            "groups": get_group_list(user, request.client),
+        }
+
+    def get_discovery_claims(self, request):
+        # Used for discovery of the available claims at the Auto Discovery Endpoint.
+        return ["name", "given_name", "family_name", "preferred_username", "email", "email_verified", "is_staff",
+                "is_superuser", "can_authenticate", "groups"]

--- a/janus/urls.py
+++ b/janus/urls.py
@@ -1,25 +1,37 @@
 from django.conf.urls import include
 from django.urls import path, re_path
 from django.utils.module_loading import import_string
-from oauth2_provider.views import TokenView, RevokeTokenView, IntrospectTokenView
+from oauth2_provider.views import TokenView, RevokeTokenView, IntrospectTokenView, UserInfoView, \
+    ConnectDiscoveryInfoView, JwksInfoView
 
 from janus import views
 from janus.oauth2.views import AuthorizationView
-
+from janus.app_settings import JANUS_OIDC_ENABLED
 
 # override profile view if django settings point to a different class
 from . import app_settings as janus_app_settings
 ProfileViewClass = import_string(janus_app_settings.ALLAUTH_JANUS_PROFILE_VIEW)
 
-
-urlpatterns = [
+oauth2_provider_patterns = [
     # use custom view, to enforce the user authenticate permissions
-    re_path(r'^o/authorize/?$', AuthorizationView.as_view(), name="authorize"),
+    re_path(r'^authorize/?$', AuthorizationView.as_view(), name="authorize"),
 
     # default oauth2_provider.url.base_urlpatterns
-    re_path(r'^o/token/?$', TokenView.as_view(), name="token"),
-    re_path(r'^o/revoke_token/?$', RevokeTokenView.as_view(), name="revoke-token"),
+    re_path(r'^token/?$', TokenView.as_view(), name="token"),
+    re_path(r'^revoke_token/?$', RevokeTokenView.as_view(), name="revoke-token"),
     re_path(r"^introspect/?$", IntrospectTokenView.as_view(), name="introspect"),
+]
+
+if JANUS_OIDC_ENABLED:
+    oauth2_provider_patterns += [
+        re_path(r'^userinfo/', UserInfoView.as_view(), name='user-info'),
+        re_path(r"^\.well-known/openid-configuration", ConnectDiscoveryInfoView.as_view(), name="oidc-connect-discovery-info"),
+        re_path(r"^\.well-known/jwks.json$", JwksInfoView.as_view(), name="jwks-info"),
+    ]
+
+urlpatterns = [
+    # include oauth2 related urls
+    re_path(r'o/', include((oauth2_provider_patterns, "oauth2_provider"))),
 
     # custom urls
     re_path(r'^o/profile/?$', ProfileViewClass.as_view(), name="profile"),

--- a/janus/views.py
+++ b/janus/views.py
@@ -9,8 +9,7 @@ from oauth2_provider.models import AccessToken, RefreshToken
 from oauth2_provider.views import ProtectedResourceView
 import json
 
-from janus.models import ProfileGroup, Profile, GroupPermission, ProfilePermission, \
-    ApplicationExtension
+from janus.oauth2.util import get_permissions, get_group_list
 
 
 class LogoutView(View):
@@ -54,149 +53,6 @@ class LogoutView(View):
 
 class ProfileView(ProtectedResourceView):
 
-    def get_profile_memberships(self, user):
-
-        all_profiles = Profile.objects.get(user=user).group.all()
-
-        # add the default groups by default
-        default_profile = ProfileGroup.objects.filter(default=True)
-        all_profiles = set(all_profiles | default_profile)
-
-        return list(all_profiles)
-
-    def get_group_permissions(self, user, application):
-        """
-        Validates the group permissions for a user given a token
-        :param user:
-        :param token:
-        :return:
-        """
-        is_staff = False
-        is_superuser = False
-        can_authenticate = False
-
-        if not user.is_authenticated:
-            return can_authenticate, is_staff, is_superuser
-
-        all_groups = self.get_profile_memberships(user)
-
-        for g in all_groups:
-            gp = GroupPermission.objects.filter(profile_group=g, application=application)
-            if gp.count() == 0:
-                continue
-            elif gp.count() == 1:
-                gp = gp.first()
-                if gp.can_authenticate:
-                    can_authenticate = True
-                if gp.is_staff:
-                    is_staff = True
-                if gp.is_superuser:
-                    is_superuser = True
-            else:
-                print('We have a problem')
-        return can_authenticate, is_staff, is_superuser
-
-    def get_personal_permissions(self, user, application):
-        """
-        Validates the personal permissions for a user given a token
-        :param user:
-        :param token:
-        :return:
-        """
-        is_staff = None
-        is_superuser = None
-        can_authenticate = None
-        if not user.is_authenticated:
-            return can_authenticate, is_staff, is_superuser
-
-        pp = ProfilePermission.objects.filter(profile__user=user, application=application).first()
-        if pp:
-            is_staff = True if pp.is_staff else None
-            is_superuser = True if pp.is_superuser else None
-            can_authenticate = True if pp.can_authenticate else None
-        return can_authenticate, is_staff, is_superuser
-
-
-    def get_profile_group_memberships(self, user, application):
-        """
-        collect group names form user profile group memberships
-        :param user:
-        :param token:
-        :return:
-        """
-
-        all_profiles = self.get_profile_memberships(user)
-
-        group_list = set()
-
-        for g in all_profiles:
-            # get profile-group-permission object
-            gp = GroupPermission.objects.filter(profile_group=g, application=application)
-            for elem in gp:
-                groups = elem.groups.all()
-
-                for g in groups:
-                    # ensure only groups for this application can be returned
-                    if g.application == application:
-                        group_list.add(g.name)
-
-        return group_list
-
-
-    def get_profile_personal_memberships(self, user, application):
-        """
-        collect group names form user profile permission
-        :param user:
-        :param token:
-        :return:
-        """
-
-        profile_permissions = ProfilePermission.objects.filter(profile__user=user, application=application).first()
-
-        group_list = set()
-
-        if profile_permissions:
-            groups = profile_permissions.groups.all()
-
-            for g in groups:
-                # ensure only groups for this application can be returned
-                if g.application == application:
-                    group_list.add(g.name)
-
-        return group_list
-
-    def get_permissions(self, user, application):
-        """
-        return permissions according to application settings, personal overwrite and default values
-        :param user:
-        :param application:
-        :return:
-        """
-        can_authenticate, is_staff, is_superuser = self.get_group_permissions(user, application)
-
-        # if set the personal settings overwrite the user settings
-        pp_authenticate, pp_staff, pp_superuser = self.get_personal_permissions(user, application)
-        if pp_staff is not None:
-            is_staff = pp_staff
-
-        if pp_superuser is not None:
-            is_superuser = pp_superuser
-
-        if pp_authenticate is not None:
-            can_authenticate = pp_authenticate
-
-        return can_authenticate, is_staff, is_superuser
-
-
-    def get_group_list(self, user, application):
-
-        groups = set()
-        groups = groups.union(self.get_profile_group_memberships(user, application))
-        groups = groups.union(self.get_profile_personal_memberships(user, application))
-
-        return list(groups)
-
-
     def get(self, request):
         if request.resource_owner:
             user = request.resource_owner
@@ -235,9 +91,9 @@ class ProfileView(ProtectedResourceView):
         :return:
         """
 
-        can_authenticate, is_staff, is_superuser = self.get_permissions(user, application)
+        can_authenticate, is_staff, is_superuser = get_permissions(user, application)
 
-        groups = self.get_group_list(user, application)
+        groups = get_group_list(user, application)
 
         data = {
             'id': user.username,


### PR DESCRIPTION
# Changes
## Additions
Adds Basic support for OIDC. If OIDC is configured for `django-oauth-toolkit` it is also enabled for `janus`.
The three endpoints `o/userinfo/`, `o/.well-known/openid-configuration` and `o/.well-known/jwks.json` are supported. Though I am not sure whether we need the JWKS endpoint.

Minimal config for `settings.py`:
```python3
OAUTH2_PROVIDER = {
    "OIDC_ENABLED": True,
    "OIDC_ISS_ENDPOINT": "[...]",
    "OAUTH2_VALIDATOR_CLASS": "janus.oauth2.validator.JanusOAuth2Validator",
    "OIDC_RSA_PRIVATE_KEY": "[...]", # Generate with `openssl genrsa -out oidc.key 4096`
    "SCOPES": {
        "openid": "Connect with your Account",
        "profile": "Access your Name and Username",
        "email": "Access your Mail-Address",
    }
}
```

## Breaking Changes:
- Introspection Endpoint is now at `o/introspect/` instead of `introspect/`.

## Fixes
- `email_verified` now returns the correct value.
